### PR TITLE
Add reverse proxy and requirements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,158 @@ data/*
 *.mseed
 .DS_Store
 clientCodes/list_of_sent_files.txt
+
+
+# Created by https://www.toptal.com/developers/gitignore/api/python
+# Edit at https://www.toptal.com/developers/gitignore?templates=python
+
+### Python ###
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+parts/
+sdist/
+var/
+wheels/
+pip-wheel-metadata/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+pytestdebug.log
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+doc/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+.python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# poetry
+#poetry.lock
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+# .env
+.env/
+.venv/
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+pythonenv*
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# operating system-related files
+# file properties cache/storage on macOS
+*.DS_Store
+# thumbnail cache on Windows
+Thumbs.db
+
+# profiling data
+.prof
+
+
+# End of https://www.toptal.com/developers/gitignore/api/python

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 python-socketio
 cryptography
-eventlet
+eventlet==0.30.2
 obspy

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+python-socketio
+cryptography
+eventlet
+obspy

--- a/serverCodes/Dockerfile
+++ b/serverCodes/Dockerfile
@@ -1,0 +1,12 @@
+FROM python:3.8.10
+
+ENV PYTHONUNBUFFERED=TRUE
+
+RUN pip install --no-cache-dir \
+    gunicorn \ 
+    python-socketio \
+    cryptography \
+    eventlet==0.30.2 \
+    obspy
+
+WORKDIR /code

--- a/serverCodes/docker-compose.yml
+++ b/serverCodes/docker-compose.yml
@@ -1,0 +1,21 @@
+version: '3'
+
+services:
+  rfi-socketio:
+    build: .
+      #expose:
+      #- 8000
+    ports:
+      - "8000:8000"
+    volumes:
+      - .:/code
+    command: bash -c "gunicorn -k eventlet -w 1 --reload app:app -b 0.0.0.0:8000"
+  proxy:
+    build: ./nginx
+    ports:
+      - "1337:1337"
+        #command: bash -c "python3 /code/server.py"
+        #volumes:
+      #- .:/code
+    depends_on:
+      - rfi-socketio

--- a/serverCodes/nginx/Dockerfile
+++ b/serverCodes/nginx/Dockerfile
@@ -1,0 +1,3 @@
+FROM nginx:1.20.0
+RUN rm /etc/nginx/conf.d/default.conf
+COPY nginx.conf /etc/nginx/

--- a/serverCodes/nginx/nginx.conf
+++ b/serverCodes/nginx/nginx.conf
@@ -1,0 +1,22 @@
+user  nginx;
+worker_processes  auto;
+
+error_log  /var/log/nginx/error.log debug;
+pid        /var/run/nginx.pid;
+
+
+events {
+    worker_connections  1024;
+}
+
+stream {
+    upstream rfi-socketio {
+        server rfi-socketio:8000;
+    }
+
+    server {
+        listen 1337;
+        proxy_pass rfi-socketio;
+        #proxy_protocol on;
+    }
+}


### PR DESCRIPTION
Add minimum reverse proxy setting.
Currently using Nginx, and you can add more settings in Nginx such as [domain name](http://nginx.org/en/docs/http/server_names.html)
and [SSL](https://docs.nginx.com/nginx/admin-guide/security-controls/terminating-ssl-http/) with ease and speed.

Also, I have add requirements for dependencies installation.